### PR TITLE
fix: harden translucent-shape rendering and NextUI theme parsing

### DIFF
--- a/pkg/gabagool/internal/helpers.go
+++ b/pkg/gabagool/internal/helpers.go
@@ -311,8 +311,13 @@ func DrawFilledCircle(renderer *sdl.Renderer, centerX, centerY, radius int32, co
 		return
 	}
 
+	// Derive the center from localRect so both paths are correct: on the
+	// scratch texture localRect is at the origin (center radius,radius), and on
+	// the fallback path (drawTranslucentShape draws straight to destRect when
+	// the scratch texture is unavailable) localRect is destRect and the circle
+	// lands back at centerX,centerY instead of the screen corner.
 	drawTranslucentShape(renderer, rect, color, func(localRect *sdl.Rect, opaqueColor sdl.Color) {
-		drawFilledCirclePrimitives(renderer, radius, radius, radius, opaqueColor)
+		drawFilledCirclePrimitives(renderer, localRect.X+radius, localRect.Y+radius, radius, opaqueColor)
 	})
 }
 
@@ -349,12 +354,24 @@ func drawTranslucentShape(renderer *sdl.Renderer, destRect *sdl.Rect, color sdl.
 	var prevBlendMode sdl.BlendMode
 	renderer.GetDrawBlendMode(&prevBlendMode)
 
-	renderer.SetRenderTarget(tex)
+	if err := renderer.SetRenderTarget(tex); err != nil {
+		// The target is left unchanged on failure, so it is safe to fall back
+		// to drawing straight to the real target rather than blitting garbage.
+		draw(destRect, color)
+		return
+	}
 	// Clear() honors the current draw blend mode; with BLENDMODE_BLEND left
-	// over from an earlier draw, clearing to alpha 0 would be a no-op and
-	// leak whatever this cached texture held from its previous use.
+	// over from an earlier draw, clearing would blend against (not overwrite)
+	// whatever this cached texture held from its previous use and leak it
+	// through, so force NONE first. Clear to the shape's own chroma at alpha 0
+	// rather than transparent black: the AA rim pixels are rasterized with
+	// coverage-weighted alpha and so still pass through BLENDMODE_BLEND when
+	// copied out. Blending them against a matching-chroma, zero-alpha
+	// background reconstructs the correct non-premultiplied color
+	// (C*w + C*(1-w) = C); clearing to black instead would leave a dark fringe
+	// (C*w against 0) around the shape.
 	renderer.SetDrawBlendMode(sdl.BLENDMODE_NONE)
-	renderer.SetDrawColor(0, 0, 0, 0)
+	renderer.SetDrawColor(color.R, color.G, color.B, 0)
 	renderer.Clear()
 
 	localRect := sdl.Rect{X: 0, Y: 0, W: destRect.W, H: destRect.H}
@@ -380,6 +397,16 @@ func getScratchTexture(renderer *sdl.Renderer, w, h int32) (*sdl.Texture, error)
 		return translucentScratchTexture, nil
 	}
 
+	// Grow to cover both the cached and requested dimensions on each axis so
+	// alternating aspect ratios (a tall pill then a wide one) don't destroy and
+	// recreate the texture every frame.
+	if translucentScratchW > w {
+		w = translucentScratchW
+	}
+	if translucentScratchH > h {
+		h = translucentScratchH
+	}
+
 	if translucentScratchTexture != nil {
 		translucentScratchTexture.Destroy()
 	}
@@ -387,6 +414,8 @@ func getScratchTexture(renderer *sdl.Renderer, w, h int32) (*sdl.Texture, error)
 	tex, err := renderer.CreateTexture(sdl.PIXELFORMAT_RGBA8888, sdl.TEXTUREACCESS_TARGET, w, h)
 	if err != nil {
 		translucentScratchTexture = nil
+		translucentScratchW = 0
+		translucentScratchH = 0
 		return nil, err
 	}
 
@@ -394,6 +423,19 @@ func getScratchTexture(renderer *sdl.Renderer, w, h int32) (*sdl.Texture, error)
 	translucentScratchW = w
 	translucentScratchH = h
 	return tex, nil
+}
+
+// destroyScratchTexture releases the cached scratch texture and resets the
+// cache. It must run before the renderer that owns the texture is destroyed:
+// the cache is a package global that outlives any single window, so a later
+// reuse would otherwise hand a freed texture back to SDL.
+func destroyScratchTexture() {
+	if translucentScratchTexture != nil {
+		translucentScratchTexture.Destroy()
+		translucentScratchTexture = nil
+		translucentScratchW = 0
+		translucentScratchH = 0
+	}
 }
 
 // DrawSmoothScrollbar renders a simple square scrollbar

--- a/pkg/gabagool/internal/window.go
+++ b/pkg/gabagool/internal/window.go
@@ -187,6 +187,9 @@ func (window *Window) closeWindow() {
 	if window.Background != nil {
 		window.Background.Destroy()
 	}
+	// Release the cached scratch texture before its owning renderer, otherwise
+	// the package-global cache dangles past this window's lifetime.
+	destroyScratchTexture()
 	window.Renderer.Destroy()
 	window.Window.Destroy()
 

--- a/pkg/gabagool/platform/nextui/nextval.go
+++ b/pkg/gabagool/platform/nextui/nextval.go
@@ -3,13 +3,15 @@ package nextui
 // NextVal represents the NextUI system configuration loaded from nextval.elf.
 // This structure matches the JSON output from the NextUI configuration utility.
 type NextVal struct {
-	Font            int    `json:"font"`
-	Color1          string `json:"color1"`
-	Color2          string `json:"color2"`
-	Color3          string `json:"color3"`
-	Color4          string `json:"color4"`
-	Color5          string `json:"color5"`
-	Color6          string `json:"color6"`
+	Font   int    `json:"font"`
+	Color1 string `json:"color1"`
+	Color2 string `json:"color2"`
+	Color3 string `json:"color3"`
+	Color4 string `json:"color4"`
+	Color5 string `json:"color5"`
+	Color6 string `json:"color6"`
+	// BGColor is NextUI's background color ("Background Color" / COLOR_BACKGROUND).
+	// Absent on builds predating the color7 setting; handled by resolveBackgroundColor.
 	BGColor         string `json:"color7"`
 	Radius          int    `json:"radius"`
 	ShowClock       int    `json:"showclock"`

--- a/pkg/gabagool/platform/nextui/theming.go
+++ b/pkg/gabagool/platform/nextui/theming.go
@@ -58,7 +58,7 @@ func InitNextUITheme() internal.Theme {
 		TextColor:            parseHexColor(nv.Color4),
 		HighlightedTextColor: parseHexColor(nv.Color5),
 		HintColor:            parseHexColor(nv.Color6),
-		BackgroundColor:      parseHexColor(nv.BGColor),
+		BackgroundColor:      resolveBackgroundColor(nv.BGColor),
 	}
 
 	if constants.IsDevMode() {
@@ -112,32 +112,66 @@ func loadNextVal() (*NextVal, error) {
 	return &nextval, nil
 }
 
-// parseHexColor parses a hex color string from nextval. NextUI accepts both
-// legacy 6-digit "RRGGBB" (opaque) and 8-digit "RRGGBBAA" strings, deciding
-// the format by digit count rather than value, so we mirror that here.
+// errorColor is returned for a non-background color that cannot be parsed. It
+// is deliberately conspicuous so a misconfigured theme is obvious on screen
+// while still leaving the rest of the UI usable.
+var errorColor = sdl.Color{R: 255, G: 0, B: 0, A: 255}
+
+// parseHexColor parses a color string from nextval, returning errorColor when
+// it cannot be parsed. Use resolveBackgroundColor for the background, whose
+// error color would fill the whole screen.
 func parseHexColor(hexStr string) sdl.Color {
+	if color, ok := tryParseHexColor(hexStr); ok {
+		return color
+	}
+	return errorColor
+}
+
+// resolveBackgroundColor parses the nextval background color, falling back to
+// the default theme's background (and logging a warning) when it is missing or
+// unparseable. Unlike other theme colors the background fills the entire
+// screen, so the errorColor sentinel would render an unusable solid-red UI;
+// the default is a sane, legible fallback instead. A missing value is expected
+// on NextUI builds predating the color7 background setting.
+func resolveBackgroundColor(hexStr string) sdl.Color {
+	if color, ok := tryParseHexColor(hexStr); ok {
+		return color
+	}
+	internal.GetInternalLogger().Warn(
+		"NextUI background color missing or unparseable; using default",
+		"value", hexStr,
+	)
+	return defaultTheme.BackgroundColor
+}
+
+// tryParseHexColor parses a hex color string from nextval. NextUI emits colors
+// as a quoted "0x%08X" RRGGBBAA string; builds predating alpha support emit
+// 6-digit RRGGBB. The format is decided by digit count rather than value, so we
+// mirror that here. Returns ok=false for anything it cannot parse.
+func tryParseHexColor(hexStr string) (sdl.Color, bool) {
 	hexStr = strings.TrimSpace(hexStr)
+	hexStr = strings.TrimPrefix(hexStr, "#")
 	hexStr = strings.TrimPrefix(hexStr, "0x")
 	hexStr = strings.TrimPrefix(hexStr, "0X")
 
 	hex, err := strconv.ParseUint(hexStr, 16, 32)
 	if err != nil {
+		return sdl.Color{}, false
+	}
+
+	switch len(hexStr) {
+	case 6:
+		// "RRGGBB" - legacy opaque format.
+		return internal.HexToColor(uint32(hex)), true
+	case 8:
+		// "RRGGBBAA" - NextUI's current format.
 		return sdl.Color{
-			R: 255,
-			G: 0,
-			B: 0,
-			A: 255,
-		}
-	}
-
-	if len(hexStr) <= 6 {
-		return internal.HexToColor(uint32(hex))
-	}
-
-	return sdl.Color{
-		R: uint8((hex >> 24) & 0xFF),
-		G: uint8((hex >> 16) & 0xFF),
-		B: uint8((hex >> 8) & 0xFF),
-		A: uint8(hex & 0xFF),
+			R: uint8((hex >> 24) & 0xFF),
+			G: uint8((hex >> 16) & 0xFF),
+			B: uint8((hex >> 8) & 0xFF),
+			A: uint8(hex & 0xFF),
+		}, true
+	default:
+		return sdl.Color{}, false
 	}
 }

--- a/pkg/gabagool/platform/nextui/theming_test.go
+++ b/pkg/gabagool/platform/nextui/theming_test.go
@@ -1,0 +1,128 @@
+package nextui
+
+import (
+	"testing"
+
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+func TestParseHexColor(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  sdl.Color
+	}{
+		{
+			name:  "rgba 8-digit",
+			input: "1E2329FF",
+			want:  sdl.Color{R: 0x1E, G: 0x23, B: 0x29, A: 0xFF},
+		},
+		{
+			name:  "rgba preserves alpha byte",
+			input: "1E232980",
+			want:  sdl.Color{R: 0x1E, G: 0x23, B: 0x29, A: 0x80},
+		},
+		{
+			name:  "rgba zero alpha",
+			input: "12345600",
+			want:  sdl.Color{R: 0x12, G: 0x34, B: 0x56, A: 0x00},
+		},
+		{
+			name:  "rgb 6-digit is opaque",
+			input: "1E2329",
+			want:  sdl.Color{R: 0x1E, G: 0x23, B: 0x29, A: 255},
+		},
+		{
+			name:  "rgb white",
+			input: "FFFFFF",
+			want:  sdl.Color{R: 0xFF, G: 0xFF, B: 0xFF, A: 255},
+		},
+		{
+			name:  "0x prefix stripped",
+			input: "0x9B2257",
+			want:  sdl.Color{R: 0x9B, G: 0x22, B: 0x57, A: 255},
+		},
+		{
+			name:  "uppercase 0X prefix stripped",
+			input: "0XFFFFFFFF",
+			want:  sdl.Color{R: 0xFF, G: 0xFF, B: 0xFF, A: 0xFF},
+		},
+		{
+			name:  "hash prefix stripped",
+			input: "#FF0000",
+			want:  sdl.Color{R: 0xFF, G: 0x00, B: 0x00, A: 255},
+		},
+		{
+			name:  "surrounding whitespace trimmed",
+			input: "  FFFFFF  ",
+			want:  sdl.Color{R: 0xFF, G: 0xFF, B: 0xFF, A: 255},
+		},
+		{
+			name:  "empty string falls back to error color",
+			input: "",
+			want:  errorColor,
+		},
+		{
+			name:  "non-hex falls back to error color",
+			input: "nothex",
+			want:  errorColor,
+		},
+		{
+			name:  "odd length falls back to error color",
+			input: "1E2329F",
+			want:  errorColor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseHexColor(tt.input)
+			if got != tt.want {
+				t.Errorf("parseHexColor(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveBackgroundColor(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  sdl.Color
+	}{
+		{
+			name:  "valid rgba is parsed",
+			input: "0x102030FF",
+			want:  sdl.Color{R: 0x10, G: 0x20, B: 0x30, A: 0xFF},
+		},
+		{
+			name:  "valid rgb is parsed",
+			input: "102030",
+			want:  sdl.Color{R: 0x10, G: 0x20, B: 0x30, A: 255},
+		},
+		{
+			// Builds predating the color7 setting emit no background key,
+			// so the field arrives empty and must not render solid red.
+			name:  "empty falls back to default theme, not error color",
+			input: "",
+			want:  defaultTheme.BackgroundColor,
+		},
+		{
+			name:  "unparseable falls back to default theme",
+			input: "nothex",
+			want:  defaultTheme.BackgroundColor,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveBackgroundColor(tt.input)
+			if got != tt.want {
+				t.Errorf("resolveBackgroundColor(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+			if got == errorColor && tt.want != errorColor {
+				t.Errorf("resolveBackgroundColor(%q) returned the error (red) color", tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-ups to #21:

Rendering:
- Draw the fallback circle at its real position (not the screen corner) when the translucent scratch texture is unavailable
- Clear the scratch texture to the shape's chroma at alpha 0 instead of transparent black, removing the dark fringe on anti-aliased edges
- Destroy the cached scratch texture before its owning renderer so the package-global cache cannot dangle across windows
- Grow the scratch texture to the max of cached/requested per axis so alternating shape sizes don't recreate it every frame
- Check SetRenderTarget errors and fall back to direct drawing

NextUI theming (verified against LoveRetro/NextUI config.c):
- Fall back to the default theme background, with a logged warning, when the background color is missing or unparseable - the red error sentinel would fill the whole screen, and a missing color7 is expected on builds predating the background setting
- Parse only the formats NextUI actually emits: 6-digit RRGGBB (legacy, opaque) and 8-digit RRGGBBAA; reject other lengths instead of misreading them
- Trim "#" and "0X" prefixes alongside "0x"
- Document that color7 is the background key; NextUI never emitted a bgcolor key, so no legacy alias is needed
- Add parseHexColor/resolveBackgroundColor table tests